### PR TITLE
Open the django admin doc model on double click

### DIFF
--- a/assets/components/Network.vue
+++ b/assets/components/Network.vue
@@ -266,6 +266,14 @@ export default {
     this.visData.edges = mountVisData(this, 'edges');
     this.network = new Network(container, this.visData, this.options);
 
+    this.network.on( 'doubleClick', function(properties) {
+      var adm_slug = properties.nodes.toString();
+      if (adm_slug.indexOf('Abstract') !== -1) {return}  //the abstract property should be inside properties
+      var n = adm_slug.lastIndexOf(".");
+      adm_slug = adm_slug.substring(n+1).replace("/", ".");
+      window.open("/admin/doc/models/" + adm_slug, '_blank');
+    });
+
     this.events.forEach(eventName =>
       this.network.on(eventName, props => this.$emit(translateEvent(eventName), props))
     );

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+"""Django's command-line utility for administrative tasks."""
+import os
+import sys
+
+
+def main():
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', "tests.settings")
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and "
+            "available on your PYTHONPATH environment variable? Did you "
+            "forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,11 +1,17 @@
 import environ
+import os
 
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 env = environ.Env()
 
-
 DEBUG = True
-DATABASES = {"default": env.db(default="sqlite://:memory:")}
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    }
+}
 ROOT_URLCONF = "tests.urls"
 SECRET_KEY = "not-for-production"
 INSTALLED_APPS = [
@@ -19,6 +25,8 @@ INSTALLED_APPS = [
     "tests.installed",
     "tests.proxy",
     "schema_graph",
+    'django.contrib.admindocs',
+    'django.contrib.admin',
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",
@@ -26,7 +34,26 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
 ]
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
 TEMPLATES = (
-    {"BACKEND": "django.template.backends.django.DjangoTemplates", "APP_DIRS": True},
+    {"BACKEND": "django.template.backends.django.DjangoTemplates",
+     "APP_DIRS": True,
+     'OPTIONS': {
+         'context_processors': [
+             'django.template.context_processors.debug',
+             'django.template.context_processors.request',
+             'django.contrib.auth.context_processors.auth',
+             'django.contrib.messages.context_processors.messages',
+         ],
+     },
+     },
 )
 STATIC_URL = "/static/"

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,13 +1,22 @@
+from django.contrib import admin
 from schema_graph.views import Schema
 
 
 try:
     # Django 2+:
-    from django.urls import path
+    from django.urls import path, include
 
-    urlpatterns = [path("", Schema.as_view())]
+    urlpatterns = [
+        path('admin/doc/', include('django.contrib.admindocs.urls')),
+        path('admin/', admin.site.urls),
+        path("", Schema.as_view())
+    ]
 except ImportError:
     # Django < 2:
     from django.conf.urls import url
 
-    urlpatterns = [url(r"^$", Schema.as_view())]
+    urlpatterns = [
+        url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
+        url('^admin/', admin.site.urls),
+        url(r"^$", Schema.as_view())
+    ]


### PR DESCRIPTION
I had this idea of landing on to the [django admindocs] (https://docs.djangoproject.com/en/3.0/ref/contrib/admin/admindocs/) when you double click on a node.
I'm not even sure if it's a good idea or not, I thought it would be good to be able to land on a more detailed description of a model if needed.