### PR TITLE
Tidy CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox tox-gh-actions
+          pip install tox tox-gh-actions pre-commit
 
       - name: Test with tox
         run: tox
+
+      - name: Run pre-commit hooks
+        run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,14 +14,13 @@ repos:
     rev: v4.3.20
     hooks:
       - id: isort
-        language_version: "python2"
+        language_version: "python3"
 
   - repo: https://github.com/ambv/black
     rev: 19.3b0
     hooks:
       - id: black
         name: black
-        language: system
         language_version: "python3"
         entry: black
         types: [python]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist =
     py37-django{111,20,21,22,30,31}
     py38-django{22,30,31}
     py39-django{22,30,31}
-    py38-codestyle
 
 [gh-actions]
 python =
@@ -15,13 +14,9 @@ python =
 
 [testenv]
 commands =
-    codestyle: black . --check --diff
-    codestyle: isort --check
-    django{111,20,21,22,30}: pytest {posargs:tests} -vv
+    pytest {posargs:tests} -vv
 deps =
-    codestyle: black==19.3b0
-    codestyle: isort~=4.3.10
-    django{111,20,21,22,30}: -rrequirements.txt
+    -rrequirements.txt
     django111: django~=1.11.0
     django20: django~=2.0.0
     django21: django~=2.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ deps =
     django21: django~=2.1.0
     django22: django~=2.2.0
     django30: django~=3.0.0
+    django31: django~=3.1.0
 setenv =
     PYTHONDONTWRITEBYTECODE=1
 usedevelop = true


### PR DESCRIPTION
- Fix Django build in Tox.
- Test `black` and `isort` with `pre-commit` in CI.
- Use Python 3 to run `isort`.