### PR TITLE
Update Black in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         language_version: "python3"
 
   - repo: https://github.com/ambv/black
-    rev: 19.3b0
+    rev: 22.3.0
     hooks:
       - id: black
         name: black


### PR DESCRIPTION
This updates to move beyond an incompatibility with click which results in the error:

`ImportError: cannot import name '_unicodefun' from 'click'`