### PR TITLE
Avoid many to many duplication when using through models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ Version numbers should follow https://semver.org/spec/v2.0.0.html
 
 - Moved from `setup.py` to `poetry` for building released packages.
 
+### Fixed
+
+- Many-to-many connections aren't added when using explicit through models.
+  The foreign-key connections from the through table are enough. #46
+
 
 ## [1.2.0] - 2020-03-01
 

--- a/schema_graph/schema.py
+++ b/schema_graph/schema.py
@@ -62,7 +62,12 @@ def get_field_relationships(model):
             one_to_one.append(relationship)
         # Many-to-many
         elif field.many_to_many and not field.auto_created:
-            many_to_many.append(relationship)
+            through_model = getattr(model, field.name).through
+            # We only add the M2M connection if the through-model is auto-created.
+            # This stops us from creating two sets of connections (because the
+            # connections will be created by the FK fields on the through model).
+            if through_model._meta.auto_created:
+                many_to_many.append(relationship)
 
     return foreign_keys, one_to_one, many_to_many
 

--- a/tests/basic/models.py
+++ b/tests/basic/models.py
@@ -19,3 +19,12 @@ class OutgoingForeignKey(models.Model):
 
 class OutgoingOneToOne(models.Model):
     connected = models.OneToOneField(Target, on_delete=models.CASCADE)
+
+
+class ThroughTable(models.Model):
+    source = models.ForeignKey("ManyToManyWithThroughTable", on_delete=models.CASCADE)
+    target = models.ForeignKey(Target, on_delete=models.CASCADE)
+
+
+class ManyToManyWithThroughTable(models.Model):
+    connected = models.ManyToManyField(Target, through=ThroughTable)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -34,11 +34,13 @@ def test_models():
         "tests.app_c": ("InterAppOneToOne",),
         "tests.app_d": ("InterAppManyToMany", "InterAppProxy"),
         "tests.basic": (
+            "ManyToManyWithThroughTable",
             "OutgoingForeignKey",
             "OutgoingManyToMany",
             "OutgoingOneToOne",
             "SelfReference",
             "Target",
+            "ThroughTable",
         ),
         "tests.generic": ("GenericFK",),
         "tests.inheritance": (
@@ -67,6 +69,11 @@ def test_foreign_key():
         (("tests.app_b", "InterAppForeignKey"), ("django.contrib.auth", "User")),
         (("tests.basic", "OutgoingForeignKey"), ("tests.basic", "Target")),
         (("tests.basic", "SelfReference"), ("tests.basic", "SelfReference")),
+        (
+            ("tests.basic", "ThroughTable"),
+            ("tests.basic", "ManyToManyWithThroughTable"),
+        ),
+        (("tests.basic", "ThroughTable"), ("tests.basic", "Target")),
         (
             ("tests.generic", "GenericFK"),
             ("django.contrib.contenttypes", "ContentType"),


### PR DESCRIPTION
This prevents many-to-many connections from showing when there is an explicit through table, to avoid duplicated connections.

**Before:**
![image](https://user-images.githubusercontent.com/767671/182130550-119078b6-bcdf-4d0d-af36-baff17dcd4df.png)

**After:** 
![image](https://user-images.githubusercontent.com/767671/182130315-e1f2b5d3-96fc-4f6a-8bc5-5b0bba5d4024.png)


Fixes #46 