### PR TITLE
Let users choose how schema graph view is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Version numbers should follow https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Added
+
+- Introduced `SCHEMA_GRAPH_VISIBLE` setting as a way to control access to the
+  `Schema` view. We will continue to default to using `DEBUG`.
+
+
+### Changed
+
+- We no longer use a decorator on the `Schema` view to override `dispatch`, and
+  now override it directly.
+
 
 ## [2.0.0] - 2022-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Version numbers should follow https://semver.org/spec/v2.0.0.html
 
 - We no longer use a decorator on the `Schema` view to override `dispatch`, and
   now override it directly.
+- It is now possible to control access to the `Schema` view by subclassing and
+  overriding the `access_permitted` function.
 
 
 ## [2.0.0] - 2022-08-01

--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ urlpatterns += [
 
 Browse to `/schema/` (assuming that's where you put it in your URLs).
 
-Note: `DEBUG` mode is required, on the assumption that you don't want to leak
-sensitive information about your website outside of local development.
+You can control access to this page using the `SCHEMA_GRAPH_VISIBLE` setting,
+or by subclassing `schema_graph.views.Schema` and overriding `access_permitted`.
+By default the page is only visible when `DEBUG` is `True`,
+because we assume that you don't want to leak sensitive information about your
+website outside of local development.
 
 ## Support
 

--- a/schema_graph/views.py
+++ b/schema_graph/views.py
@@ -10,8 +10,12 @@ from schema_graph.schema import get_schema
 class Schema(TemplateView):
     template_name = "schema_graph/schema.html"
 
+    def access_permitted(self):
+        """When this returns True, the schema graph page is accessible."""
+        return settings.DEBUG
+
     def dispatch(self, request):
-        if not settings.DEBUG:
+        if not self.access_permitted():
             raise Http404()
         return super().dispatch(request)
 

--- a/schema_graph/views.py
+++ b/schema_graph/views.py
@@ -11,8 +11,16 @@ class Schema(TemplateView):
     template_name = "schema_graph/schema.html"
 
     def access_permitted(self):
-        """When this returns True, the schema graph page is accessible."""
-        return settings.DEBUG
+        """
+        When this returns True, the schema graph page is accessible.
+
+        We look for the setting `SCHEMA_GRAPH_VISIBLE`, and fall back to `DEBUG`.
+
+        To control this on a per-request basis, override this function in a subclass.
+        The request will be accessible using `self.request`.
+        """
+
+        return getattr(settings, "SCHEMA_GRAPH_VISIBLE", settings.DEBUG)
 
     def dispatch(self, request):
         if not self.access_permitted():

--- a/schema_graph/views.py
+++ b/schema_graph/views.py
@@ -2,24 +2,18 @@ import json
 
 from django.conf import settings
 from django.http import Http404
-from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 
 from schema_graph.schema import get_schema
 
 
-def debug_required(view_function):
-    def view_wrapper(request, *args, **kwargs):
-        if not settings.DEBUG:
-            raise Http404()
-        return view_function(request, *args, **kwargs)
-
-    return view_wrapper
-
-
-@method_decorator(debug_required, name="dispatch")
 class Schema(TemplateView):
     template_name = "schema_graph/schema.html"
+
+    def dispatch(self, request):
+        if not settings.DEBUG:
+            raise Http404()
+        return super().dispatch(request)
 
     def get_context_data(self, **kwargs):
         schema = get_schema()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -36,19 +36,35 @@ def test_content():
     assert response.rendered_content.startswith("<!doctype html>")
 
 
-def test_debug():
-    """Schema should be accessible in DEBUG mode."""
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        # SCHEMA_GRAPH_VISIBLE takes priority over DEBUG.
+        {"DEBUG": True, "SCHEMA_GRAPH_VISIBLE": True},
+        {"DEBUG": False, "SCHEMA_GRAPH_VISIBLE": True},
+        {"DEBUG": True},
+    ],
+)
+def test_accessible_settings(settings_dict):
     view = Schema.as_view()
     request = create_request()
-    with override_settings(DEBUG=True):
+    with override_settings(**settings_dict):
         response = view(request)
     assert response.status_code == 200
 
 
-def test_no_debug():
-    """Schema should be inaccessible outwith DEBUG mode."""
+@pytest.mark.parametrize(
+    "settings_dict",
+    [
+        # SCHEMA_GRAPH_VISIBLE takes priority over DEBUG.
+        {"DEBUG": True, "SCHEMA_GRAPH_VISIBLE": False},
+        {"DEBUG": False, "SCHEMA_GRAPH_VISIBLE": False},
+        {"DEBUG": False},
+    ],
+)
+def test_inaccessible_settings(settings_dict):
     view = Schema.as_view()
     request = create_request()
-    with override_settings(DEBUG=False):
+    with override_settings(**settings_dict):
         with pytest.raises(Http404):
             view(request)


### PR DESCRIPTION
This re-arranges the `schema_graph.views.Schema` to allow for two ways of overriding access:

- In cases where a setting provides enough control, the `SCHEMA_GRAPH_VISIBLE` setting can be used. (`DEBUG` will be used as a default when this setting is not found.)

- In cases where more fine-grained control is required, `Schema` can be subclassed, and `access_permitted` can be overridden.