### PR TITLE
Drop support for old Python and Django versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - name: Checkout the code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Version numbers should follow https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Backwards incompatible
+
+- Dropped support for Django < 3.2.
+- Dropped support for Python < 3.10.
+
 ## [2.2.1] - 2022-10-26
 
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -60,16 +60,18 @@ website outside of local development.
 ## Support
 
 Tests run on sensible combinations of:
-- Python (3.6-3.11)
-- Django (1.11-4.1)
+- Python (3.10-3.11)
+- Django (3.2-4.1)
 
 If you're stuck on old version of Python or Django, you may consider installing
 old versions.
 They will probably have fewer features, and there will be no support for them.
 
-The last version to support Python 2.7 and 3.5 was 1.2.0
+The last version to support Python 2.7 and 3.5 was 1.2.0.
+The last version to support Python 3.6 to 3.9 was 2.2.1.
 
-The last version to support Django 1.8 was 1.2.0
+The last version to support Django 1.8 was 1.2.0.
+The last version to support Django 1.9 to 3.1 was 2.2.1.
 
 ## Alternatives
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,6 @@ readme = "README.md"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Framework :: Django",
-    "Framework :: Django :: 1.11",
-    "Framework :: Django :: 2.0",
-    "Framework :: Django :: 2.1",
-    "Framework :: Django :: 2.2",
-    "Framework :: Django :: 3.0",
-    "Framework :: Django :: 3.1",
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.0",
     "Framework :: Django :: 4.1",
@@ -27,10 +21,6 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Topic :: Database",
@@ -40,7 +30,7 @@ classifiers = [
 
 
 [tool.poetry.dependencies]
-python = ">=3.6"
+python = ">=3.10"
 attrs = ">=21.4.0"
 
 [tool.poetry.dev-dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ python =
 commands =
     python -m pytest {posargs:tests} -vv
 deps =
+    attrs>=21.4.0
     django-environ>=0.4.5
     pytest>=6.2.2
     pytest-django>=4.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,5 @@
 [tox]
 envlist =
-    py36-django{111,20,21,22,30,31,32}
-    py37-django{111,20,21,22,30,31,32}
-    py38-django{22,30,31,32,40,41}
-    py39-django{22,30,31,32,40,41}
     py310-django{32,40,41}
     py311-django{32,40,41}
 
@@ -11,10 +7,6 @@ isolated_build = True
 
 [gh-actions]
 python =
-    3.6: py36
-    3.7: py37
-    3.8: py38
-    3.9: py39
     3.10: py310
     3.11: py311
 
@@ -26,12 +18,6 @@ deps =
     pytest>=6.2.2
     pytest-django>=4.1.0
 
-    django111: django~=1.11.0
-    django20: django~=2.0.0
-    django21: django~=2.1.0
-    django22: django~=2.2.0
-    django30: django~=3.0.0
-    django31: django~=3.1.0
     django32: django~=3.2.0
     django40: django~=4.0.0
     django41: django~=4.1.0


### PR DESCRIPTION
Python 3.10 and Django 3.2 are now the minimum supported versions.