### PR TITLE
Rework schema data structure

### DIFF
--- a/schema_graph/schema.py
+++ b/schema_graph/schema.py
@@ -1,65 +1,70 @@
-from collections import defaultdict
+from __future__ import annotations
 
-from attr import attrib, attrs
-from django.apps import apps
+from collections.abc import Iterator
+
+import attrs
+from django import apps
 from django.db import models
 
 
-@attrs
-class Schema:
-    # Vertices
-    abstract_models = attrib()
-    models = attrib()
-    proxies = attrib()
-    # Edges
-    foreign_keys = attrib()
-    inheritance = attrib()
-    many_to_manys = attrib()
-    one_to_ones = attrib()
+@attrs.frozen(order=True)
+class Node:
+    id: str
+    name: str
+    group: str
+    tags: tuple[str, ...] = ()
+
+    @classmethod
+    def from_model(cls, model: type[models.Model]) -> Node:
+        tags = []
+        if model._meta.proxy:
+            tags.append("proxy")
+        if model._meta.abstract:
+            tags.append("abstract")
+        return cls(
+            id=get_model_id(model),
+            name=model.__name__,
+            group=get_app_name(model),
+            tags=tuple(tags),
+        )
 
 
-def get_app_models():
-    for app in apps.get_app_configs():
-        for model in app.get_models():
-            yield app, model
+@attrs.frozen(order=True)
+class Edge:
+    source: str
+    target: str
+    tags: tuple[str, ...] = ()
 
+    @classmethod
+    def proxy(cls, child: type[models.Model], parent: type[models.Model]) -> Edge:
+        return cls(get_model_id(child), get_model_id(parent), tags=("proxy",))
 
-def get_model_id(model):
-    app_label = model._meta.app_label
-    try:
-        app_name = apps.get_app_config(app_label).name
-    except LookupError:
-        app_name = model.__module__
+    @classmethod
+    def subclass(cls, child: type[models.Model], parent: type[models.Model]) -> Edge:
+        return cls(get_model_id(child), get_model_id(parent), tags=("subclass",))
 
-    return (app_name, model.__name__)
-
-
-def get_field_relationships(model):
-    foreign_keys = []
-    one_to_one = []
-    many_to_many = []
-
-    model_id = get_model_id(model)
-
-    for field in model._meta.get_fields():
+    @classmethod
+    def from_field(
+        cls, model: type[models.Model], field: type[models.fields.Field]
+    ) -> Edge | None:
         # Ignore non-relation fields
         if not field.is_relation:
-            continue
+            return None
         # Skip fields defined on superclasses
         if field.model != model:
-            continue
+            return None
         related_model = field.related_model
         # GenericForeignKey
         if related_model is None:
-            continue
+            return None
+        model_id = get_model_id(model)
         related_model_id = get_model_id(related_model)
-        relationship = (model_id, related_model_id)
         # Foreign key
         if field.many_to_one:
-            foreign_keys.append(relationship)
-        # One-to-one
+            return cls(model_id, related_model_id)
+        # One to one
         elif field.one_to_one and not field.auto_created:
-            one_to_one.append(relationship)
+            return cls(model_id, related_model_id, tags=("one-to-one",))
         # Many-to-many
         elif field.many_to_many and not field.auto_created:
             through_model = getattr(model, field.name).through
@@ -67,9 +72,31 @@ def get_field_relationships(model):
             # This stops us from creating two sets of connections (because the
             # connections will be created by the FK fields on the through model).
             if through_model._meta.auto_created:
-                many_to_many.append(relationship)
+                return cls(model_id, related_model_id, tags=("many-to-many",))
 
-    return foreign_keys, one_to_one, many_to_many
+
+@attrs.frozen
+class Graph:
+    nodes: tuple[Node, ...]
+    edges: tuple[Edge, ...]
+
+
+def get_app_models() -> Iterator[tuple[apps.AppConfig, type[models.Model]]]:
+    for app in apps.apps.get_app_configs():
+        for model in app.get_models():
+            yield app, model
+
+
+def get_app_name(model: type[models.Model]) -> str:
+    app_label = model._meta.app_label
+    try:
+        return apps.apps.get_app_config(app_label).name
+    except LookupError:
+        return model.__module__
+
+
+def get_model_id(model: type[models.Model]) -> str:
+    return f"{model.__module__}.{model.__name__}"
 
 
 def is_model_subclass(obj):
@@ -78,56 +105,32 @@ def is_model_subclass(obj):
     return issubclass(obj, models.Model)
 
 
-def get_schema():
-    abstract_nodes = defaultdict(set)
-    nodes = defaultdict(tuple)
-    foreign_keys = []
-    one_to_one = []
-    many_to_many = []
-    inheritance = set()
-    proxy = []
+def get_schema() -> Graph:
+    nodes = []
+    edges = []
 
     for app, model in get_app_models():
-        app_label, model_name = model_id = get_model_id(model)
-        nodes[app_label] += (model_name,)
+        nodes.append(Node.from_model(model))
 
         # Proxy models
         if model._meta.proxy:
-            related_model_id = get_model_id(model._meta.proxy_for_model)
-            relationship = (model_id, related_model_id)
-            proxy.append(relationship)
+            edges.append(Edge.proxy(model, model._meta.proxy_for_model))
             continue
 
         # Subclassing
         for base in filter(is_model_subclass, model.__mro__):
-            base_app_label, base_model_name = get_model_id(base)
-            if base._meta.abstract:
-                abstract_nodes[base_app_label].add(base_model_name)
+            nodes.append(Node.from_model(base))
             for parent in filter(is_model_subclass, base.__bases__):
-                inheritance.add(
-                    ((base_app_label, base_model_name), get_model_id(parent))
-                )
+                edges.append(Edge.subclass(base, parent))
 
-        # Fields
-        fks, o2o, m2m = get_field_relationships(model)
-        foreign_keys.extend(fks)
-        one_to_one.extend(o2o)
-        many_to_many.extend(m2m)
+        # Relationships
+        for field in model._meta.get_fields():
+            edge = Edge.from_field(model, field)
+            if edge is None:
+                continue
+            edges.append(edge)
 
-    for app_label in nodes:
-        nodes[app_label] = tuple(sorted(nodes[app_label]))
-
-    for app_label in abstract_nodes:
-        abstract_nodes[app_label] = tuple(sorted(abstract_nodes[app_label]))
-
-    return Schema(
-        # Vertices
-        abstract_models=dict(abstract_nodes),
-        models=dict(nodes),
-        proxies=sorted(proxy),
-        # Edges
-        foreign_keys=sorted(foreign_keys),
-        inheritance=sorted(inheritance),
-        many_to_manys=sorted(many_to_many),
-        one_to_ones=sorted(one_to_one),
+    return Graph(
+        nodes=tuple(sorted(set(nodes))),
+        edges=tuple(sorted(set(edges))),
     )

--- a/schema_graph/views.py
+++ b/schema_graph/views.py
@@ -29,15 +29,24 @@ class Schema(TemplateView):
 
     def get_context_data(self, **kwargs):
         schema = get_schema()
+
+        abstract_models = schema.abstract_models
+        models = schema.models
+        foreign_keys = schema.foreign_keys
+        many_to_manys = schema.many_to_manys
+        one_to_ones = schema.one_to_ones
+        inheritance = schema.inheritance
+        proxies = schema.proxies
+
         kwargs.update(
             {
-                "abstract_models": json.dumps(schema.abstract_models),
-                "models": json.dumps(schema.models),
-                "foreign_keys": json.dumps(schema.foreign_keys),
-                "many_to_manys": json.dumps(schema.many_to_manys),
-                "one_to_ones": json.dumps(schema.one_to_ones),
-                "inheritance": json.dumps(schema.inheritance),
-                "proxies": json.dumps(schema.proxies),
+                "abstract_models": json.dumps(abstract_models),
+                "models": json.dumps(models),
+                "foreign_keys": json.dumps(foreign_keys),
+                "many_to_manys": json.dumps(many_to_manys),
+                "one_to_ones": json.dumps(one_to_ones),
+                "inheritance": json.dumps(inheritance),
+                "proxies": json.dumps(proxies),
             }
         )
         return super().get_context_data(**kwargs)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,188 +1,421 @@
 import django
 
-from schema_graph.schema import get_schema
+from schema_graph import schema
 
 
 DJANGO_LT_19 = django.VERSION < (1, 9, 0)
 
 
-def test_abstract_models():
-    expected = {
-        "django.contrib.auth": ("AbstractBaseUser", "AbstractUser", "PermissionsMixin"),
-        "django.contrib.sessions": ("AbstractBaseSession",),
-        "tests.inheritance": (
-            "Abstract",
-            "AbstractBase",
-            "AbstractSubclass1",
-            "AbstractSubclass2",
+def test_nodes():
+    assert schema.get_schema().nodes == (
+        schema.Node(
+            id="django.contrib.auth.base_user.AbstractBaseUser",
+            name="AbstractBaseUser",
+            group="django.contrib.auth",
+            tags=("abstract",),
         ),
-        "tests.not_installed.models": ("AbstractNotInstalled",),
-    }
-    if DJANGO_LT_19:
-        expected.pop("django.contrib.sessions")
-    assert get_schema().abstract_models == expected
-
-
-def test_models():
-    expected = {
-        "django.contrib.auth": ("Group", "Permission", "User"),
-        "django.contrib.contenttypes": ("ContentType",),
-        "django.contrib.sessions": ("Session",),
-        "django.contrib.sites": ("Site",),
-        "tests.app_a": ("InterAppSubclass",),
-        "tests.app_b": ("InterAppForeignKey",),
-        "tests.app_c": ("InterAppOneToOne",),
-        "tests.app_d": ("InterAppManyToMany", "InterAppProxy"),
-        "tests.basic": (
-            "ManyToManyWithThroughTable",
-            "OutgoingForeignKey",
-            "OutgoingManyToMany",
-            "OutgoingOneToOne",
-            "SelfReference",
-            "Target",
-            "ThroughTable",
+        schema.Node(
+            id="django.contrib.auth.models.AbstractUser",
+            name="AbstractUser",
+            group="django.contrib.auth",
+            tags=("abstract",),
         ),
-        "tests.generic": ("GenericFK",),
-        "tests.inheritance": (
-            "AbstractMultipleInheritance",
-            "Concrete",
-            "ConcreteBase",
-            "ConcreteInheritance",
-            "ConcreteSubclass1",
-            "ConcreteSubclass2",
-            "MixedMultipleInheritance",
-            "SubSubclass",
-            "Subclass",
+        schema.Node(
+            id="django.contrib.auth.models.Group",
+            name="Group",
+            group="django.contrib.auth",
         ),
-        "tests.installed": ("ConcreteInstalled",),
-        "tests.proxy": ("ProxyNode", "ProxyNode2", "Target"),
-    }
-    assert get_schema().models == expected
+        schema.Node(
+            id="django.contrib.auth.models.Permission",
+            name="Permission",
+            group="django.contrib.auth",
+        ),
+        schema.Node(
+            id="django.contrib.auth.models.PermissionsMixin",
+            name="PermissionsMixin",
+            group="django.contrib.auth",
+            tags=("abstract",),
+        ),
+        schema.Node(
+            id="django.contrib.auth.models.User",
+            name="User",
+            group="django.contrib.auth",
+        ),
+        schema.Node(
+            id="django.contrib.contenttypes.models.ContentType",
+            name="ContentType",
+            group="django.contrib.contenttypes",
+        ),
+        schema.Node(
+            id="django.contrib.sessions.base_session.AbstractBaseSession",
+            name="AbstractBaseSession",
+            group="django.contrib.sessions",
+            tags=("abstract",),
+        ),
+        schema.Node(
+            id="django.contrib.sessions.models.Session",
+            name="Session",
+            group="django.contrib.sessions",
+        ),
+        schema.Node(
+            id="django.contrib.sites.models.Site",
+            name="Site",
+            group="django.contrib.sites",
+        ),
+        schema.Node(
+            id="tests.app_a.models.InterAppSubclass",
+            name="InterAppSubclass",
+            group="tests.app_a",
+        ),
+        schema.Node(
+            id="tests.app_b.models.InterAppForeignKey",
+            name="InterAppForeignKey",
+            group="tests.app_b",
+        ),
+        schema.Node(
+            id="tests.app_c.models.InterAppOneToOne",
+            name="InterAppOneToOne",
+            group="tests.app_c",
+        ),
+        schema.Node(
+            id="tests.app_d.models.InterAppManyToMany",
+            name="InterAppManyToMany",
+            group="tests.app_d",
+        ),
+        schema.Node(
+            id="tests.app_d.models.InterAppProxy",
+            name="InterAppProxy",
+            group="tests.app_d",
+            tags=("proxy",),
+        ),
+        schema.Node(
+            id="tests.basic.models.ManyToManyWithThroughTable",
+            name="ManyToManyWithThroughTable",
+            group="tests.basic",
+        ),
+        schema.Node(
+            id="tests.basic.models.OutgoingForeignKey",
+            name="OutgoingForeignKey",
+            group="tests.basic",
+        ),
+        schema.Node(
+            id="tests.basic.models.OutgoingManyToMany",
+            name="OutgoingManyToMany",
+            group="tests.basic",
+        ),
+        schema.Node(
+            id="tests.basic.models.OutgoingOneToOne",
+            name="OutgoingOneToOne",
+            group="tests.basic",
+        ),
+        schema.Node(
+            id="tests.basic.models.SelfReference",
+            name="SelfReference",
+            group="tests.basic",
+        ),
+        schema.Node(
+            id="tests.basic.models.Target",
+            name="Target",
+            group="tests.basic",
+        ),
+        schema.Node(
+            id="tests.basic.models.ThroughTable",
+            name="ThroughTable",
+            group="tests.basic",
+        ),
+        schema.Node(
+            id="tests.generic.models.GenericFK",
+            name="GenericFK",
+            group="tests.generic",
+        ),
+        schema.Node(
+            id="tests.inheritance.models.Abstract",
+            name="Abstract",
+            tags=("abstract",),
+            group="tests.inheritance",
+        ),
+        schema.Node(
+            id="tests.inheritance.models.AbstractBase",
+            name="AbstractBase",
+            group="tests.inheritance",
+            tags=("abstract",),
+        ),
+        schema.Node(
+            id="tests.inheritance.models.AbstractMultipleInheritance",
+            name="AbstractMultipleInheritance",
+            group="tests.inheritance",
+        ),
+        schema.Node(
+            id="tests.inheritance.models.AbstractSubclass1",
+            name="AbstractSubclass1",
+            group="tests.inheritance",
+            tags=("abstract",),
+        ),
+        schema.Node(
+            id="tests.inheritance.models.AbstractSubclass2",
+            name="AbstractSubclass2",
+            group="tests.inheritance",
+            tags=("abstract",),
+        ),
+        schema.Node(
+            id="tests.inheritance.models.Concrete",
+            name="Concrete",
+            group="tests.inheritance",
+        ),
+        schema.Node(
+            id="tests.inheritance.models.ConcreteBase",
+            name="ConcreteBase",
+            group="tests.inheritance",
+        ),
+        schema.Node(
+            id="tests.inheritance.models.ConcreteInheritance",
+            name="ConcreteInheritance",
+            group="tests.inheritance",
+        ),
+        schema.Node(
+            id="tests.inheritance.models.ConcreteSubclass1",
+            name="ConcreteSubclass1",
+            group="tests.inheritance",
+        ),
+        schema.Node(
+            id="tests.inheritance.models.ConcreteSubclass2",
+            name="ConcreteSubclass2",
+            group="tests.inheritance",
+        ),
+        schema.Node(
+            id="tests.inheritance.models.MixedMultipleInheritance",
+            name="MixedMultipleInheritance",
+            group="tests.inheritance",
+        ),
+        schema.Node(
+            id="tests.inheritance.models.SubSubclass",
+            name="SubSubclass",
+            group="tests.inheritance",
+        ),
+        schema.Node(
+            id="tests.inheritance.models.Subclass",
+            name="Subclass",
+            group="tests.inheritance",
+        ),
+        schema.Node(
+            id="tests.installed.models.ConcreteInstalled",
+            name="ConcreteInstalled",
+            group="tests.installed",
+        ),
+        schema.Node(
+            id="tests.not_installed.models.AbstractNotInstalled",
+            name="AbstractNotInstalled",
+            group="tests.not_installed.models",
+            tags=("abstract",),
+        ),
+        schema.Node(
+            id="tests.proxy.models.ProxyNode",
+            name="ProxyNode",
+            group="tests.proxy",
+            tags=("proxy",),
+        ),
+        schema.Node(
+            id="tests.proxy.models.ProxyNode2",
+            name="ProxyNode2",
+            group="tests.proxy",
+            tags=("proxy",),
+        ),
+        schema.Node(
+            id="tests.proxy.models.Target",
+            name="Target",
+            group="tests.proxy",
+        ),
+    )
 
 
-def test_foreign_key():
+def test_edges():
     expected = [
-        (
-            ("django.contrib.auth", "Permission"),
-            ("django.contrib.contenttypes", "ContentType"),
+        schema.Edge(
+            "django.contrib.auth.models.AbstractUser",
+            "django.contrib.auth.base_user.AbstractBaseUser",
+            tags=("subclass",),
         ),
-        (("tests.app_b", "InterAppForeignKey"), ("django.contrib.auth", "User")),
-        (("tests.basic", "OutgoingForeignKey"), ("tests.basic", "Target")),
-        (("tests.basic", "SelfReference"), ("tests.basic", "SelfReference")),
-        (
-            ("tests.basic", "ThroughTable"),
-            ("tests.basic", "ManyToManyWithThroughTable"),
+        schema.Edge(
+            "django.contrib.auth.models.AbstractUser",
+            "django.contrib.auth.models.PermissionsMixin",
+            tags=("subclass",),
         ),
-        (("tests.basic", "ThroughTable"), ("tests.basic", "Target")),
-        (
-            ("tests.generic", "GenericFK"),
-            ("django.contrib.contenttypes", "ContentType"),
+        schema.Edge(
+            "django.contrib.auth.models.Group",
+            "django.contrib.auth.models.Permission",
+            tags=("many-to-many",),
         ),
-    ]
-    assert get_schema().foreign_keys == expected
-
-
-def test_one_to_one():
-    expected = [
-        (("tests.app_c", "InterAppOneToOne"), ("tests.app_b", "InterAppForeignKey")),
-        (("tests.basic", "OutgoingOneToOne"), ("tests.basic", "Target")),
-        (
-            ("tests.inheritance", "ConcreteSubclass2"),
-            ("tests.inheritance", "ConcreteBase"),
+        schema.Edge(
+            "django.contrib.auth.models.Permission",
+            "django.contrib.contenttypes.models.ContentType",
         ),
-    ]
-    assert get_schema().one_to_ones == expected
-
-
-def test_many_to_many():
-    expected = [
-        (("django.contrib.auth", "Group"), ("django.contrib.auth", "Permission")),
-        (("django.contrib.auth", "User"), ("django.contrib.auth", "Group")),
-        (("django.contrib.auth", "User"), ("django.contrib.auth", "Permission")),
-        (("tests.app_d", "InterAppManyToMany"), ("tests.app_b", "InterAppForeignKey")),
-        (("tests.basic", "OutgoingManyToMany"), ("tests.basic", "Target")),
-    ]
-    assert get_schema().many_to_manys == expected
-
-
-def test_inheritance():
-    expected = [
-        (
-            ("django.contrib.auth", "AbstractUser"),
-            ("django.contrib.auth", "AbstractBaseUser"),
+        schema.Edge(
+            "django.contrib.auth.models.User",
+            "django.contrib.auth.models.AbstractUser",
+            tags=("subclass",),
         ),
-        (
-            ("django.contrib.auth", "AbstractUser"),
-            ("django.contrib.auth", "PermissionsMixin"),
+        schema.Edge(
+            "django.contrib.auth.models.User",
+            "django.contrib.auth.models.Group",
+            tags=("many-to-many",),
         ),
-        (("django.contrib.auth", "User"), ("django.contrib.auth", "AbstractUser")),
-        (
-            ("django.contrib.sessions", "Session"),
-            ("django.contrib.sessions", "AbstractBaseSession"),
+        schema.Edge(
+            "django.contrib.auth.models.User",
+            "django.contrib.auth.models.Permission",
+            tags=("many-to-many",),
         ),
-        (("tests.app_a", "InterAppSubclass"), ("django.contrib.auth", "Group")),
-        (
-            ("tests.inheritance", "AbstractMultipleInheritance"),
-            ("tests.inheritance", "AbstractSubclass1"),
+        schema.Edge(
+            "django.contrib.sessions.models.Session",
+            "django.contrib.sessions.base_session.AbstractBaseSession",
+            tags=("subclass",),
         ),
-        (
-            ("tests.inheritance", "AbstractMultipleInheritance"),
-            ("tests.inheritance", "AbstractSubclass2"),
+        schema.Edge(
+            "tests.app_a.models.InterAppSubclass",
+            "django.contrib.auth.models.Group",
+            tags=("subclass",),
         ),
-        (
-            ("tests.inheritance", "AbstractSubclass1"),
-            ("tests.inheritance", "AbstractBase"),
+        schema.Edge(
+            "tests.app_b.models.InterAppForeignKey",
+            "django.contrib.auth.models.User",
         ),
-        (
-            ("tests.inheritance", "AbstractSubclass2"),
-            ("tests.inheritance", "AbstractBase"),
+        schema.Edge(
+            "tests.app_c.models.InterAppOneToOne",
+            "tests.app_b.models.InterAppForeignKey",
+            tags=("one-to-one",),
         ),
-        (("tests.inheritance", "Concrete"), ("tests.inheritance", "Abstract")),
-        (
-            ("tests.inheritance", "ConcreteInheritance"),
-            ("tests.inheritance", "ConcreteSubclass1"),
+        schema.Edge(
+            "tests.app_d.models.InterAppManyToMany",
+            "tests.app_b.models.InterAppForeignKey",
+            tags=("many-to-many",),
         ),
-        (
-            ("tests.inheritance", "ConcreteInheritance"),
-            ("tests.inheritance", "ConcreteSubclass2"),
+        schema.Edge(
+            "tests.app_d.models.InterAppProxy",
+            "tests.app_c.models.InterAppOneToOne",
+            tags=("proxy",),
         ),
-        (
-            ("tests.inheritance", "ConcreteSubclass1"),
-            ("tests.inheritance", "ConcreteBase"),
+        schema.Edge(
+            "tests.basic.models.OutgoingForeignKey",
+            "tests.basic.models.Target",
         ),
-        (
-            ("tests.inheritance", "ConcreteSubclass2"),
-            ("tests.inheritance", "ConcreteBase"),
+        schema.Edge(
+            "tests.basic.models.OutgoingManyToMany",
+            "tests.basic.models.Target",
+            tags=("many-to-many",),
         ),
-        (
-            ("tests.inheritance", "MixedMultipleInheritance"),
-            ("tests.inheritance", "AbstractBase"),
+        schema.Edge(
+            "tests.basic.models.OutgoingOneToOne",
+            "tests.basic.models.Target",
+            tags=("one-to-one",),
         ),
-        (
-            ("tests.inheritance", "MixedMultipleInheritance"),
-            ("tests.inheritance", "ConcreteBase"),
+        schema.Edge(
+            "tests.basic.models.SelfReference",
+            "tests.basic.models.SelfReference",
         ),
-        (("tests.inheritance", "SubSubclass"), ("tests.inheritance", "Subclass")),
-        (("tests.inheritance", "Subclass"), ("tests.inheritance", "ConcreteBase")),
-        (
-            ("tests.installed", "ConcreteInstalled"),
-            ("tests.not_installed.models", "AbstractNotInstalled"),
+        schema.Edge(
+            "tests.basic.models.ThroughTable",
+            "tests.basic.models.ManyToManyWithThroughTable",
+        ),
+        schema.Edge(
+            "tests.basic.models.ThroughTable",
+            "tests.basic.models.Target",
+        ),
+        schema.Edge(
+            "tests.generic.models.GenericFK",
+            "django.contrib.contenttypes.models.ContentType",
+        ),
+        schema.Edge(
+            "tests.inheritance.models.AbstractMultipleInheritance",
+            "tests.inheritance.models.AbstractSubclass1",
+            tags=("subclass",),
+        ),
+        schema.Edge(
+            "tests.inheritance.models.AbstractMultipleInheritance",
+            "tests.inheritance.models.AbstractSubclass2",
+            tags=("subclass",),
+        ),
+        schema.Edge(
+            "tests.inheritance.models.AbstractSubclass1",
+            "tests.inheritance.models.AbstractBase",
+            tags=("subclass",),
+        ),
+        schema.Edge(
+            "tests.inheritance.models.AbstractSubclass2",
+            "tests.inheritance.models.AbstractBase",
+            tags=("subclass",),
+        ),
+        schema.Edge(
+            "tests.inheritance.models.Concrete",
+            "tests.inheritance.models.Abstract",
+            tags=("subclass",),
+        ),
+        schema.Edge(
+            "tests.inheritance.models.ConcreteInheritance",
+            "tests.inheritance.models.ConcreteSubclass1",
+            tags=("subclass",),
+        ),
+        schema.Edge(
+            "tests.inheritance.models.ConcreteInheritance",
+            "tests.inheritance.models.ConcreteSubclass2",
+            tags=("subclass",),
+        ),
+        schema.Edge(
+            "tests.inheritance.models.ConcreteSubclass1",
+            "tests.inheritance.models.ConcreteBase",
+            tags=("subclass",),
+        ),
+        schema.Edge(
+            "tests.inheritance.models.ConcreteSubclass2",
+            "tests.inheritance.models.ConcreteBase",
+            tags=("one-to-one",),
+        ),
+        schema.Edge(
+            "tests.inheritance.models.ConcreteSubclass2",
+            "tests.inheritance.models.ConcreteBase",
+            tags=("subclass",),
+        ),
+        schema.Edge(
+            "tests.inheritance.models.MixedMultipleInheritance",
+            "tests.inheritance.models.AbstractBase",
+            tags=("subclass",),
+        ),
+        schema.Edge(
+            "tests.inheritance.models.MixedMultipleInheritance",
+            "tests.inheritance.models.ConcreteBase",
+            tags=("subclass",),
+        ),
+        schema.Edge(
+            "tests.inheritance.models.SubSubclass",
+            "tests.inheritance.models.Subclass",
+            tags=("subclass",),
+        ),
+        schema.Edge(
+            "tests.inheritance.models.Subclass",
+            "tests.inheritance.models.ConcreteBase",
+            tags=("subclass",),
+        ),
+        schema.Edge(
+            "tests.installed.models.ConcreteInstalled",
+            "tests.not_installed.models.AbstractNotInstalled",
+            tags=("subclass",),
+        ),
+        schema.Edge(
+            "tests.proxy.models.ProxyNode",
+            "tests.proxy.models.Target",
+            tags=("proxy",),
+        ),
+        schema.Edge(
+            "tests.proxy.models.ProxyNode2",
+            "tests.proxy.models.Target",
+            tags=("proxy",),
         ),
     ]
     if DJANGO_LT_19:
         expected.remove(
-            (
-                ("django.contrib.sessions", "Session"),
-                ("django.contrib.sessions", "AbstractBaseSession"),
+            schema.Edge(
+                "django.contrib.sessions.models.Session",
+                "django.contrib.sessions.models.AbstractBaseSession",
+                tags=("subclass",),
             )
         )
-    assert get_schema().inheritance == expected
 
-
-def test_proxy():
-    expected = [
-        (("tests.app_d", "InterAppProxy"), ("tests.app_c", "InterAppOneToOne")),
-        (("tests.proxy", "ProxyNode"), ("tests.proxy", "Target")),
-        (("tests.proxy", "ProxyNode2"), ("tests.proxy", "Target")),
-    ]
-    assert get_schema().proxies == expected
+    assert schema.get_schema().edges == tuple(expected)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4,7 +4,6 @@ import pytest
 from django.http import Http404
 from django.test import RequestFactory, override_settings
 
-from schema_graph.schema import get_schema
 from schema_graph.views import Schema
 
 
@@ -17,14 +16,151 @@ def test_context():
     request = create_request()
     view = Schema(request=request)
     context = view.get_context_data()
-    schema = get_schema()
-    assert json.loads(context["abstract_models"]) == schema.abstract_models
-    assert json.loads(context["models"]) == schema.models
-    assert json.loads(context["foreign_keys"]) == schema.foreign_keys
-    assert json.loads(context["many_to_manys"]) == schema.many_to_manys
-    assert json.loads(context["one_to_ones"]) == schema.one_to_ones
-    assert json.loads(context["inheritance"]) == schema.inheritance
-    assert json.loads(context["proxies"]) == schema.proxies
+    assert json.loads(context["abstract_models"]) == {
+        "django.contrib.auth": ["AbstractBaseUser", "AbstractUser", "PermissionsMixin"],
+        "django.contrib.sessions": ["AbstractBaseSession"],
+        "tests.inheritance": [
+            "Abstract",
+            "AbstractBase",
+            "AbstractSubclass1",
+            "AbstractSubclass2",
+        ],
+        "tests.not_installed.models": ["AbstractNotInstalled"],
+    }
+    assert json.loads(context["models"]) == {
+        "django.contrib.auth": ["Group", "Permission", "User"],
+        "django.contrib.contenttypes": ["ContentType"],
+        "django.contrib.sessions": ["Session"],
+        "django.contrib.sites": ["Site"],
+        "tests.app_a": ["InterAppSubclass"],
+        "tests.app_b": ["InterAppForeignKey"],
+        "tests.app_c": ["InterAppOneToOne"],
+        "tests.app_d": ["InterAppManyToMany", "InterAppProxy"],
+        "tests.basic": [
+            "ManyToManyWithThroughTable",
+            "OutgoingForeignKey",
+            "OutgoingManyToMany",
+            "OutgoingOneToOne",
+            "SelfReference",
+            "Target",
+            "ThroughTable",
+        ],
+        "tests.generic": ["GenericFK"],
+        "tests.inheritance": [
+            "AbstractMultipleInheritance",
+            "Concrete",
+            "ConcreteBase",
+            "ConcreteInheritance",
+            "ConcreteSubclass1",
+            "ConcreteSubclass2",
+            "MixedMultipleInheritance",
+            "SubSubclass",
+            "Subclass",
+        ],
+        "tests.installed": ["ConcreteInstalled"],
+        "tests.proxy": ["ProxyNode", "ProxyNode2", "Target"],
+    }
+    assert json.loads(context["foreign_keys"]) == [
+        [
+            ["django.contrib.auth", "Permission"],
+            ["django.contrib.contenttypes", "ContentType"],
+        ],
+        [["tests.app_b", "InterAppForeignKey"], ["django.contrib.auth", "User"]],
+        [["tests.basic", "OutgoingForeignKey"], ["tests.basic", "Target"]],
+        [["tests.basic", "SelfReference"], ["tests.basic", "SelfReference"]],
+        [
+            ["tests.basic", "ThroughTable"],
+            ["tests.basic", "ManyToManyWithThroughTable"],
+        ],
+        [["tests.basic", "ThroughTable"], ["tests.basic", "Target"]],
+        [
+            ["tests.generic", "GenericFK"],
+            ["django.contrib.contenttypes", "ContentType"],
+        ],
+    ]
+    assert json.loads(context["many_to_manys"]) == [
+        [["django.contrib.auth", "Group"], ["django.contrib.auth", "Permission"]],
+        [["django.contrib.auth", "User"], ["django.contrib.auth", "Group"]],
+        [["django.contrib.auth", "User"], ["django.contrib.auth", "Permission"]],
+        [["tests.app_d", "InterAppManyToMany"], ["tests.app_b", "InterAppForeignKey"]],
+        [["tests.basic", "OutgoingManyToMany"], ["tests.basic", "Target"]],
+    ]
+    assert json.loads(context["one_to_ones"]) == [
+        [["tests.app_c", "InterAppOneToOne"], ["tests.app_b", "InterAppForeignKey"]],
+        [["tests.basic", "OutgoingOneToOne"], ["tests.basic", "Target"]],
+        [
+            ["tests.inheritance", "ConcreteSubclass2"],
+            ["tests.inheritance", "ConcreteBase"],
+        ],
+    ]
+    assert json.loads(context["inheritance"]) == [
+        [
+            ["django.contrib.auth", "AbstractUser"],
+            ["django.contrib.auth", "AbstractBaseUser"],
+        ],
+        [
+            ["django.contrib.auth", "AbstractUser"],
+            ["django.contrib.auth", "PermissionsMixin"],
+        ],
+        [["django.contrib.auth", "User"], ["django.contrib.auth", "AbstractUser"]],
+        [
+            ["django.contrib.sessions", "Session"],
+            ["django.contrib.sessions", "AbstractBaseSession"],
+        ],
+        [["tests.app_a", "InterAppSubclass"], ["django.contrib.auth", "Group"]],
+        [
+            ["tests.inheritance", "AbstractMultipleInheritance"],
+            ["tests.inheritance", "AbstractSubclass1"],
+        ],
+        [
+            ["tests.inheritance", "AbstractMultipleInheritance"],
+            ["tests.inheritance", "AbstractSubclass2"],
+        ],
+        [
+            ["tests.inheritance", "AbstractSubclass1"],
+            ["tests.inheritance", "AbstractBase"],
+        ],
+        [
+            ["tests.inheritance", "AbstractSubclass2"],
+            ["tests.inheritance", "AbstractBase"],
+        ],
+        [["tests.inheritance", "Concrete"], ["tests.inheritance", "Abstract"]],
+        [
+            ["tests.inheritance", "ConcreteInheritance"],
+            ["tests.inheritance", "ConcreteSubclass1"],
+        ],
+        [
+            ["tests.inheritance", "ConcreteInheritance"],
+            ["tests.inheritance", "ConcreteSubclass2"],
+        ],
+        [
+            ["tests.inheritance", "ConcreteSubclass1"],
+            ["tests.inheritance", "ConcreteBase"],
+        ],
+        [
+            ["tests.inheritance", "ConcreteSubclass2"],
+            ["tests.inheritance", "ConcreteBase"],
+        ],
+        [
+            ["tests.inheritance", "MixedMultipleInheritance"],
+            ["tests.inheritance", "AbstractBase"],
+        ],
+        [
+            ["tests.inheritance", "MixedMultipleInheritance"],
+            ["tests.inheritance", "ConcreteBase"],
+        ],
+        [["tests.inheritance", "SubSubclass"], ["tests.inheritance", "Subclass"]],
+        [["tests.inheritance", "Subclass"], ["tests.inheritance", "ConcreteBase"]],
+        [
+            ["tests.installed", "ConcreteInstalled"],
+            ["tests.not_installed.models", "AbstractNotInstalled"],
+        ],
+    ]
+    assert json.loads(context["proxies"]) == [
+        [["tests.app_d", "InterAppProxy"], ["tests.app_c", "InterAppOneToOne"]],
+        [["tests.proxy", "ProxyNode"], ["tests.proxy", "Target"]],
+        [["tests.proxy", "ProxyNode2"], ["tests.proxy", "Target"]],
+    ]
 
 
 def test_content():

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -18,6 +18,7 @@ def test_context():
     view = Schema(request=request)
     context = view.get_context_data()
     schema = get_schema()
+    assert json.loads(context["abstract_models"]) == schema.abstract_models
     assert json.loads(context["models"]) == schema.models
     assert json.loads(context["foreign_keys"]) == schema.foreign_keys
     assert json.loads(context["many_to_manys"]) == schema.many_to_manys

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -18,12 +18,12 @@ def test_context():
     view = Schema(request=request)
     context = view.get_context_data()
     schema = get_schema()
-    assert context["models"] == json.dumps(schema.models)
-    assert context["foreign_keys"] == json.dumps(schema.foreign_keys)
-    assert context["many_to_manys"] == json.dumps(schema.many_to_manys)
-    assert context["one_to_ones"] == json.dumps(schema.one_to_ones)
-    assert context["inheritance"] == json.dumps(schema.inheritance)
-    assert context["proxies"] == json.dumps(schema.proxies)
+    assert json.loads(context["models"]) == schema.models
+    assert json.loads(context["foreign_keys"]) == schema.foreign_keys
+    assert json.loads(context["many_to_manys"]) == schema.many_to_manys
+    assert json.loads(context["one_to_ones"]) == schema.one_to_ones
+    assert json.loads(context["inheritance"]) == schema.inheritance
+    assert json.loads(context["proxies"]) == schema.proxies
 
 
 def test_content():


### PR DESCRIPTION
We used to generate the schema with each type of edge and node in a different list.

This instead groups everything into edges or nodes, and marks those differences with "tags" such as `"abstract"` etc.

Some work is done in the view to convert back into the old format so that the work on the front-end can be handled separately.