### PR TITLE
Add pre-commit upgrade hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,15 @@ repos:
         language_version: "python3"
         entry: black
         types: [python]
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.4.0
+    hooks:
+      - id: pyupgrade
+        args: [--py310-plus]
+
+  - repo: https://github.com/adamchainz/django-upgrade
+    rev: "1.13.0"
+    hooks:
+      - id: django-upgrade
+        args: [--target-version, "3.2"]

--- a/schema_graph/schema.py
+++ b/schema_graph/schema.py
@@ -6,7 +6,7 @@ from django.db import models
 
 
 @attrs
-class Schema(object):
+class Schema:
     # Vertices
     abstract_models = attrib()
     models = attrib()

--- a/schema_graph/views.py
+++ b/schema_graph/views.py
@@ -40,4 +40,4 @@ class Schema(TemplateView):
                 "proxies": json.dumps(schema.proxies),
             }
         )
-        return super(Schema, self).get_context_data(**kwargs)
+        return super().get_context_data(**kwargs)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,13 +1,6 @@
+from django.urls import path
+
 from schema_graph.views import Schema
 
 
-try:
-    # Django 2+:
-    from django.urls import path
-
-    urlpatterns = [path("", Schema.as_view())]
-except ImportError:
-    # Django < 2:
-    from django.conf.urls import url
-
-    urlpatterns = [url(r"^$", Schema.as_view())]
+urlpatterns = [path("", Schema.as_view())]


### PR DESCRIPTION
`pyupgrade` and `django-upgrade` will help with removing old compatibility hacks, and keep the code up to date with latest conventions.