### PR TITLE
Add tooltip on node hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Version numbers should follow https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Added
+
+- Hovering over a node now shows a tooltip with its name, group, and tags.
+
 ## [3.0.0] - 2023-05-14
 
 ### Backwards incompatible

--- a/assets/state/graphData.js
+++ b/assets/state/graphData.js
@@ -17,9 +17,29 @@ const makeGroupNode = (group) => {
 };
 
 const makeNode = (node, background, border, nodeModifiers) => {
+  let title = `
+    <dl style="display: grid; grid-template-columns: auto auto; grid-auto-columns: 1fr; gap: 5px .5em; align-items: baseline;">
+      <dt style="text-align: right">name:</dt>
+        <dd><code style="border: 1px solid ${border}; background-color: ${background};">
+          ${node.name}
+        </code></dd>
+      <dt style="text-align: right">group:</dt>
+        <dd><code style="border: 1px solid ${border}; background-color: ${background};">
+          ${node.group}
+        </code></dd>
+  `;
+  if (node.tags.length) {
+    title += '<dt style="text-align: right">tags:</dt><dd>';
+    for (let tag of node.tags) {
+      title += `<code style="border: 1px solid #999;">${tag}</code> `;
+    }
+    title += '</dd>';
+  }
+  title += '</dl>';
   let nodeData = {
     id: node.id,
     label: node.name,
+    title: title,
     color: {
       background,
       border,


### PR DESCRIPTION
This tooltip lists the group name, which might help to find the node in the editor (especially in cases where the colours might be confused).

The tags are also displayed directly. These are something of an implementation detail at the moment, but it can't hurt to display them.

The fact that I've had to put HTML code into this state object to achieve this suggests that I'll need to think more about refactoring this module in future.

![image](https://github.com/meshy/django-schema-graph/assets/767671/d1fbea55-af89-4165-a7c8-e13c3dd3aac1)
